### PR TITLE
fix: bug if 2 guesses and use clue

### DIFF
--- a/client/src/components/crosswordClue.js
+++ b/client/src/components/crosswordClue.js
@@ -107,12 +107,12 @@ function CrosswordClue(props) {
           >
             Crossword clue
           </div>
-          {renderGetCrosswordClueModal()}
-          {renderCrosswordClueResultModal()}
         </>
       ) : (
         <div className="clue clue-disabled">Crossword clue</div>
       )}
+      {renderGetCrosswordClueModal()}
+      {renderCrosswordClueResultModal()}
     </>
   );
 }


### PR DESCRIPTION
Moved rendering clue result modals outside of check of whether current guess index + 2 < MAX_GUESSES.

When clue was used, current guess index was incremented, making the branch that contained the modal rendering logic unexecuted. Now moved modal logic outside of the conditional, fixing the bug.